### PR TITLE
French Version Is Now WAAAAAAY Better

### DIFF
--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -5,15 +5,15 @@
 	},
 	"appDesc": {
 		"description": "App description.",
-		"message": "Recevez des notifications lorsque les utilisateurs de YouTube sélectionnés télécharger une nouvelle vidéo."
+		"message": "Recevez des notifications lorsque les utilisateurs de YouTube sélectionnés envoient une nouvelle vidéo."
 	},
 	"settings_newVersion": {
 		"description": "The button displayed when there is a new version",
-		"message": "Nouvelle version!"
+		"message": "Nouvelle version !"
 	},
 	"settings_headerTabs1": {
 		"description": "The first tab text: Newest Uploads",
-		"message": "Derniers Envois"
+		"message": "Derniers envois"
 	},
 	"settings_headerTabs2": {
 		"description": "The second tab text: Edit Settings",
@@ -25,47 +25,47 @@
 	},
 	"settings_noChannels_header": {
 		"description": "The channels list, content header text if no channels are found",
-		"message": "Aucun Canaux Trouvés"
+		"message": "Aucunes chaînes trouvées"
 	},
 	"settings_noChannels_subheader": {
 		"description": "The channels list, content subheader text if no channels are found",
-		"message": "Importer Abonnements"
+		"message": "Importer vos abonnements"
 	},
 	"settings_editSettings_useNotifications": {
 		"description": "The label for the enable notifications checkbox",
-		"message": "Utilisez Notifications"
+		"message": "Utiliser des notifications"
 	},
 	"settings_editSettings_notificationVolume": {
 		"description": "The label for the notification volume slider",
-		"message": "Notification Volume"
+		"message": "Volume des notifications"
 	},
 	"settings_editSettings_notificationTest": {
 		"description": "The label for the notification test button",
-		"message": "Tester"
+		"message": "Essayer"
 	},
 	"settings_editSettings_tts": {
 		"description": "The label for the enable text-to-speech checkbox",
-		"message": "Utilisez Text-To-Speech"
+		"message": "Utilisez la synthèse vocale"
 	},
 	"settings_editSettings_ttsVoice": {
 		"description": "The label for the text-to-speech selector",
-		"message": "Text-To-Speech Voix"
+		"message": "Voix pour la synthèse vocale"
 	},
 	"settings_editSettings_addButtons": {
 		"description": "The label for the enable add buttons checkbox",
-		"message": "Ajouter des boutons sur YouTube"
+		"message": "Activer le bouton \"Ajouter\" sur YouTube"
 	},
 	"settings_editSettings_addButtonsSubs": {
 		"description": "The label for the view subscriptions button",
-		"message": "Voir les Souscriptions"
+		"message": "Voir les abonnements"
 	},
 	"settings_editSettings_manualRefresh": {
 		"description": "The label for the manual refresh button",
-		"message": "Actualiser Manuel"
+		"message": "Actualisation manuelle"
 	},
 	"settings_editSettings_importSubscription": {
 		"description": "The label for the import subscription button",
-		"message": "Abonnements d'Importation"
+		"message": "Importation d'abonnements"
 	},
 	"settings_editSettings_importSubscriptionChange": {
 		"description": "The label for the change user subscription button",
@@ -73,15 +73,15 @@
 	},
 	"settings_editSettings_notificationSound": {
 		"description": "The label for the notification sounds label",
-		"message": "Son de Notification"
+		"message": "Son de notification"
 	},
 	"settings_editSettings_uploadSound": {
 		"description": "The label for the upload sound button",
-		"message": "Ajouter son"
+		"message": "Ajouter un son"
 	},
 	"settings_vertSettings_viewChangelog": {
 		"description": "The label for the view changelog button",
-		"message": "Voir le Changelog"
+		"message": "Voir les changelogs"
 	},
 	"settings_vertSettings_help": {
 		"description": "The label for the help button",
@@ -93,19 +93,19 @@
 	},
 	"settings_vertSettings_channelAlignment2": {
 		"description": "The label for the edit channel layout finish button",
-		"message": "Sauvegarder les Modifications"
+		"message": "Sauvegarder les modifications"
 	},
 	"settings_vertSettings_sortMode": {
 		"description": "The label for the sort mode button",
-		"message": "Mode Tri"
+		"message": "Mode de triage"
 	},
 	"settings_vertSettings_sortMode_custom": {
 		"description": "The label for the sort mode: custom",
-		"message": "Défini par l'utilisateur"
+		"message": "Personalisé"
 	},
 	"settings_vertSettings_sortMode_latestUpload": {
 		"description": "The label for the sort mode: latestUpload",
-		"message": "Dernières Upload"
+		"message": "Plus récentes"
 	},
 	"settings_vertSettings_sortMode_abc": {
 		"description": "The label for the sort mode: abc",
@@ -113,7 +113,7 @@
 	},
 	"settings_addChannel_title": {
 		"description": "The label for the title of the add channel popup",
-		"message": "Ajouter Chaînes & Playlists"
+		"message": "Ajouter des chaînes & playlists"
 	},
 	"settings_addChannel_placeholder": {
 		"description": "The placeholder label for the add channel textbox",
@@ -133,11 +133,11 @@
 	},
 	"settings_changelog_close": {
 		"description": "The label for the changelog's close button",
-		"message": "Près"
+		"message": "Fermer"
 	},
 	"settings_importChannels_title": {
 		"description": "The label for the title of the import channels popup",
-		"message": "Importer des Canaux"
+		"message": "Importer des chaînes"
 	},
 	"settings_importChannels_cancel": {
 		"description": "The label for the change channel's cancel button",
@@ -149,11 +149,11 @@
 	},
 	"settings_importChannels_check": {
 		"description": "The label for the import channel's check all button",
-		"message": "Vérifie tout"
+		"message": "Tout Cocher"
 	},
 	"settings_importChannels_uncheck": {
 		"description": "The label for the import channel's uncheck all button",
-		"message": "Décocher tout"
+		"message": "Tout Décocher"
 	},
 	"settings_importChannels_titlePrefix": {
 		"description": "The prefix for the import channel popup's title",
@@ -161,7 +161,7 @@
 	},
 	"settings_importChannels_titleSuffix": {
 		"description": "The suffix for the import channel popup's title",
-		"message": "canaux au total"
+		"message": "Toutes les chaînes"
 	},
 	"settings_importChannels_contentOverRecommended": {
 		"description": "The label for the import channel popup's content for over recommended amount of channels",
@@ -169,15 +169,15 @@
 	},
 	"settings_importChannels_contentDuplicate": {
 		"description": "The label for the import channel popup's content for duplicate channels",
-		"message": "Canaux en double ne seront pas ajoutés."
+		"message": "Les chaînes dupliquées ne seront pas ajoutées."
 	},
 	"settings_importChannels_contentStatisticsTitle": {
 		"description": "The title label for the import channel popup's content for statistics",
-		"message": "Toutes les 5 minutes, cela se traduit par..."
+		"message": "Toutes les 5 minutes, cela donneras..."
 	},
 	"settings_importChannels_contentStatisticsRequests": {
 		"description": "The suffix for the import channel popup's content for statistics requests",
-		"message": "demandes"
+		"message": "requêtes"
 	},
 	"settings_importChannels_contentStatisticsDownloads": {
 		"description": "The suffix for the import channel popup's content for statistics downloads",
@@ -185,7 +185,7 @@
 	},
 	"settings_importChannelsSelection_title": {
 		"description": "The title of the import channel selection popup",
-		"message": "Sélectionner les canaux à l'importation"
+		"message": "Sélectionner les chaînes à importer"
 	},
 	"settings_searchPlaceholder": {
 		"description": "The label for the search input",
@@ -197,23 +197,23 @@
 	},
 	"settingsJs_saved": {
 		"description": "",
-		"message": "Sauvés"
+		"message": "Sauvegarder"
 	},
 	"settingsJs_userRemoveChannel": {
 		"description": "",
-		"message": "Enlever chaîne YouTube: "
+		"message": "Chaines supprimées: "
 	},
 	"settingsJs_addChannelsFailed": {
 		"description": "",
-		"message": "Impossible d'ajouter tous les canaux entrés"
+		"message": "Impossible d'ajouter toutes les chaînes"
 	},
 	"settingsJs_pleaseWait": {
 		"description": "",
-		"message": "S'il vous plaît, attendez..."
+		"message": "Veuillez patienter..."
 	},
 	"settingsJs_pleaseWaitWhile": {
 		"description": "",
-		"message": "S'il vous plaît patienter, cela peut prendre un certain temps..."
+		"message": "Veuillez patienter, cela peut prendre un certain temps..."
 	},
 	"settingsJs_notificationSound_default": {
 		"description": "",
@@ -221,11 +221,11 @@
 	},
 	"settingsJs_uploading": {
 		"description": "",
-		"message": "L'ajout..."
+		"message": "Envoie..."
 	},
 	"settingsJs_uploadComplete": {
 		"description": "",
-		"message": "Mettre en Linge Complet"
+		"message": "Envoie Terminé"
 	},
 	"common_published": {
 		"description": "First letter is capitalized",
@@ -241,11 +241,11 @@
 	},
 	"common_likes": {
 		"description": "",
-		"message": "aime"
+		"message": "aiment"
 	},
 	"common_dislikes": {
 		"description": "",
-		"message": "dégoûts"
+		"message": "n'aiment pas"
 	},
 	"common_ago": {
 		"description": "Ex: Published 12 hours ago",
@@ -305,7 +305,7 @@
 	},
 	"background_notificationClose": {
 		"description": "",
-		"message": "Près"
+		"message": "Fermer"
 	},
 	"background_notificationWatchLater": {
 		"description": "",
@@ -313,15 +313,15 @@
 	},
 	"background_notificationLogCheck": {
 		"description": "",
-		"message": "Vérification YouTube utilisateur: "
+		"message": "Vérification de l'utilisateur YouTube: "
 	},
 	"background_notificationLogNew": {
 		"description": "",
-		"message": "A trouvé nouvelle vidéo youtube pour: "
+		"message": "Nouvelle vidéo YouTube trouvée de: "
 	},
 	"background_snackbarNoNewVideos": {
 		"description": "",
-		"message": "Pas de nouveaux vidéos trouvées"
+		"message": "Pas de nouvelle vidéo trouvé"
 	},
 	"background_connectSuccess": {
 		"description": "",
@@ -337,35 +337,35 @@
 	},
 	"background_updateChannelsComplete": {
 		"description": "",
-		"message": "Fini la mise à jour chaînes YouTube"
+		"message": "Mise à jour des chaînes YouTube terminée"
 	},
 	"background_updateChannelsFailed": {
 		"description": "",
-		"message": "Impossible de mettre à jour chaînes YouTube"
+		"message": "Impossible de mettre à jour les chaînes YouTube"
 	},
 	"background_updateChannelsFailedChannelPrefix": {
 		"description": "",
-		"message": "Chaîne Youtube: "
+		"message": "Les chaîne Youtube: "
 	},
 	"background_updateChannelsFailedChannelSuffix": {
 		"description": "",
-		"message": " ne pouvait être vérifiée"
+		"message": " n'ont pas pus être vérifiée"
 	},
 	"background_addChannelInit": {
 		"description": "",
-		"message": "Ajout canal: "
+		"message": "Ajout de la chaîne: "
 	},
 	"background_addChannelFailed": {
 		"description": "",
-		"message": "Impossible d'ajouter le canal: "
+		"message": "Impossible d'ajouter la chaîne: "
 	},
 	"background_removeChannel": {
 		"description": "",
-		"message": "Retrait canal: "
+		"message": "Suppression de la chaîne: "
 	},
 	"background_removedChannel": {
 		"description": "",
-		"message": "Canal enlevé: "
+		"message": "Chaîne supprimée: "
 	},
 	"background_importFailed": {
 		"description": "",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -85,7 +85,7 @@
 	},
 	"settings_vertSettings_help": {
 		"description": "The label for the help button",
-		"message": "Aider"
+		"message": "Aide"
 	},
 	"settings_vertSettings_channelAlignment": {
 		"description": "The label for the edit channel layout button",


### PR DESCRIPTION
Okay, seriously, how did you translate that, with google translate... no, google translate does better translations...
Whatever, I fixed it

List of changes:

```
All:
    The material design rules recommend using uppercase only for the first letter of each sentences, so capitalised words in the middle of a sentence were un-capitalised (More infos: https://material.google.com/style/writing.html#writing-capitalization-punctuation )

appDesc:
    "Télécharger" mean Download, since there is no word for "upload" in french, google use the verb "envoyer" (send)

settings_noChannels_header,
settings_importChannels_title,
settings_importChannels_titleSuffix,
settings_importChannels_contentDuplicate,
settings_importChannelsSelection_title,
settingsJs_addChannelsFailed,
background_addChannelInit,
background_addChannelFailed,
background_removeChannel,
background_removedChannel:
    When you Google Translated "channel", google translate gave you the wrong definition of "channel".
    "canal" (and canaux) refer to: "a length of water wider than a strait, joining two larger areas of water, especially two seas."

    The correct word is "chaîne", which means "a band of frequencies used in radio and television transmission, especially as used by a particular station."
    So that's the correct word for TV Channel and other channel like that, even YouTube (they're called like that on the french YouTube)

settings_noChannels_subheader:
    You have to say "Import your subscriptions"

settings_editSettings_useNotifications:
    You have to say "Use the notifications" (it's correct in french)

settings_editSettings_notificationVolume:
    Untranslated line (?)

settings_editSettings_notificationTest:
    "tester" = "to test"
    "essayer" = "try"
    I think "try" fit this situation better, you're trying a new configuration, you don't test it

settings_editSettings_ttsVoice,
settings_editSettings_tts:
    Text-To-Speech is English

settings_editSettings_addButtons:
    "Ajouter des boutons sur YouTube" = "Add some buttons on YouTube" (it kinda made me laugh)
    "Activer le bouton "Ajouter" sur YouTube" = "Enable the button "Add" on YouTube"

settings_editSettings_addButtonsSubs:
    It's correct, but french YouTube uses the term "abonnements"...

settings_editSettings_manualRefresh:
    "Actualiser manuel" = "Actualise manual"
    "Actualisation manuelle" = "Manual actualisation"

settings_editSettings_importSubscription:
    "Abonnements d'Importation" = "Subscription of Importation"
    "Importation d'abonnements" = "Importation of subscription"

settings_editSettings_uploadSound:
    You must say "Add a sound", "Add sound" doesn't work in french

settings_vertSettings_viewChangelog:
    Since there are multiples changelogs, "les changelogs" is more appropriate

settings_vertSettings_sortMode:
    "Sort Mode" sounds weird in french, so I replaced it with "Sorting mode" (which sounds better in french)

settings_vertSettings_sortMode_custom:
    "Défini par l'utilisateur" = "Defined by the user"
    "Personnalisé" = "Custom"
    it's simpler

settings_vertSettings_sortMode_latestUpload:
    "Most recent" is simpler than "latest uploaded"

settings_addChannel_title:
    You must say "Add some channels and playlists", "Add channels and playlists" doesn't work in french

settings_changelog_close,
background_notificationClose:
    "Près" mean "near" XD

settings_importChannels_check:
    here, check has been translated like "check if it's still working", which is not what we want

settings_importChannels_uncheck:
    "Tout décocher" just feels more natural

settings_importChannels_contentStatisticsTitle:
    So, I've never seen this string being displayed, and I don't know if I translated it well, could I have an example ?

settings_importChannels_contentStatisticsRequests:
    It's just better

settingsJs_saved:
    "Sauver" mean "save" like in "save the world", "sauvegarder" mean "save" like in "save your preferences"

settingsJs_userRemoveChannel:
    The English version says "removed", but the french one contains "remove"

settingsJs_pleaseWait,
settingsJs_pleaseWaitWhile:
    "Veuillez patienter" is much more commonly used for loading times than "S'il vous plaît, attendez..."

settingsJs_uploading:
    Fit better in this context

settingsJs_uploadComplete:
    "Envoie Terminé" is much simpler than "Mettre en Linge Complet" and it is grammatically correct

background_notificationLogCheck:
    "Vérification YouTube utilisateur: " = "Verification YouTube user: "
    "Vérification de l'utilisateur YouTube: " = "Verification of the YouTube user: "

background_notificationLogNew:
    You just can't make a sentence like that in french, it sounds like a Russian is saying this

background_snackbarNoNewVideos:
    "Nouveaux vidéos" is grammatically incorrect and must be replaced with "Nouvelles vidéos"

background_updateChannelsComplete:
    Even if it's kinda correct, "Mise à jour des chaînes YouTube terminée" sounds way better

background_updateChannelsFailed,
background_updateChannelsFailedChannelPrefix:
    Needed a "the" at "the YouTube channels"

background_updateChannelsFailedChannelSuffix:
    Using "ne pouvait" implies that the operation failed long ago, while using "n'ont pas pus" implies that the operation just failed seconds ago
```

Thanks for this amazing extension by the way ;-), you're an incredible developer, I really like it
If you're not okay with any of my changes, tell me, and I can fix it
