### PR TITLE
Updated french localisations

### DIFF
--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -191,6 +191,10 @@
 		"description": "The label for the search input",
 		"message": "Chercher..."
 	},
+	"settings_addMissingChannel": {
+ 		"description": "The label for the empty channels subheader",
+ 		"message": "Ajouter cette chaîne"
+ 	},
 	"settingsJs_updating": {
 		"description": "",
 		"message": "Mise à jour..."


### PR DESCRIPTION
I translated the new "Add channel" button when searching for a channel that doesn't exist
